### PR TITLE
Add a public API to deserialize IR to AuditRule

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -17,7 +17,7 @@ func AddRule(r AuditRule) (err error) {
 	client, err := libaudit.NewAuditClient(nil)
 	defer client.Close()
 	if err != nil {
-		return fmt.Errorf("failed to initialize client %s", err.Error)
+		return fmt.Errorf("failed to initialize client %s", err.Error())
 	}
 	err = client.AddRule(ard.toWireFormat())
 	if err != nil {

--- a/cmd/libauditgo-cli.go
+++ b/cmd/libauditgo-cli.go
@@ -31,7 +31,8 @@ func main() {
 	case deleteCommand.FullCommand():
 		deleteRules(*deleteCommandInput)
 	default:
-		fmt.Errorf("not a valid option")
+		fmt.Fprintln(os.Stderr, "not a valid option")
+		os.Exit(1)
 	}
 }
 
@@ -63,7 +64,7 @@ func addRules(filePath string) {
 func printRules() {
 	auditRuleData, err := libauditgo.GetRules()
 	if err != nil {
-		fmt.Errorf("failed. %s", err.Error())
+		fmt.Fprintln(os.Stderr, "failed", err.Error())
 		return
 	}
 	if len(auditRuleData) == 0 {
@@ -72,7 +73,7 @@ func printRules() {
 	}
 	rules, err := json.MarshalIndent(auditRuleData, "", "  ")
 	if err != nil {
-		fmt.Errorf("failed. %s", err.Error())
+		fmt.Fprintln(os.Stderr, "failed", err.Error())
 		return
 	}
 
@@ -83,7 +84,7 @@ func deleteRules(filePath string) {
 	if filePath == "" {
 		num, err := libauditgo.DeleteAllRules()
 		if err != nil {
-			fmt.Errorf("failed. %s", err.Error())
+			fmt.Fprintln(os.Stderr, "failed", err.Error())
 			return
 		}
 		if num > 0 {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,57 @@
+package parser
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/open-osquery/libauditgo"
+)
+
+// UnmarshalAuditRule is json.Unmarshal style deserialiser that accepts a string
+// that represents an audit rule in the intermediate representation (ir) and
+// constructs a libauditgo.AuditRule out of it with some validations enforced.
+// Sample Usage:
+//  var rule libauditgo.SyscallAuditRule
+//  ir := `{"syscalls": ["write", "read"], "action": "always", "filters": "exit"}`
+//  UnmarshalAuditRule(ir, &rule)
+func UnmarshalAuditRule(rule string, v libauditgo.AuditRule) error {
+	var err error
+	switch r := v.(type) {
+	case *libauditgo.SyscallAuditRule:
+		if err = json.Unmarshal([]byte(rule), v); err == nil {
+			return validateSyscallAuditRule(r)
+		}
+	case *libauditgo.FileAuditRule:
+		if err = json.Unmarshal([]byte(rule), v); err == nil {
+			return validateFileAuditRule(r)
+		}
+	default:
+		return errors.New("Invalid rule for serialization")
+	}
+
+	return err
+}
+
+func validateFileAuditRule(rule *libauditgo.FileAuditRule) error {
+	if len(rule.Path) == 0 {
+		return errors.New("Missing 'path' field")
+	}
+
+	return nil
+}
+
+func validateSyscallAuditRule(rule *libauditgo.SyscallAuditRule) error {
+	if len(rule.Action) == 0 {
+		return errors.New("Missing 'action' field")
+	}
+
+	if len(rule.Filter) == 0 {
+		return errors.New("Require atleast one 'matching rules'")
+	}
+
+	if rule.Syscalls == nil || len(rule.Syscalls) == 0 {
+		return errors.New("Missing 'syscalls' list")
+	}
+
+	return nil
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,181 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/open-osquery/libauditgo"
+)
+
+var (
+	syscallRules = map[string]string{
+		"valid_rule": `{
+			"action": "always",
+			"syscalls":["execve", "read"],
+			"keys": ["useless_rule"],
+			"filter": "exit"
+		}`,
+
+		"missing_action": `{
+			"syscalls": ["execve"],
+			"keys": [],
+			"filter": "exit"
+		}`,
+
+		"invalid_ir": `{
+			"action": "always",
+			"syscalls": "something",
+			"keys": ["useless_rule"],
+			"filter": "exit"
+		}`,
+
+		"invalid_obj": `{
+			"foo": "bar",
+			"baz": ["qux"]
+		}`,
+	}
+
+	fileAuditRules = map[string]string{
+		"valid_rule": `{
+			"path": "/etc/hosts",
+			"permissions": "rwxa",
+			"keys": ["file"]
+		}`,
+
+		"missing_file_path": `{
+			"permissions": "rwxa",
+			"keys": ["file"]
+		}`,
+
+		"missing_file_perm": `{
+			"path": "/etc/hosts",
+			"keys": ["file"]
+		}`,
+		"invalid_ir": `{
+			"path": "/etc/hosts",
+			"permissions": "something",
+			"keys": "useless_rule"
+		}`,
+
+		"invalid_perm": `{
+			"path": "/etc/hosts",
+			"permissions": "something",
+			"keys": ["useless_rule"]
+		}`,
+
+		"invalid_obj": `{
+			"foo": "bar",
+			"baz": ["qux"]
+		}`,
+	}
+)
+
+func TestUnmarshalFileAuditRule(t *testing.T) {
+	t.Run("valid_rule", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["valid_rule"], &fileRule)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+
+		if fileRule.Path != "/etc/hosts" ||
+			fileRule.Permissions != "rwxa" ||
+			fileRule.Keys[0] != "file" {
+			t.Error("Missing expected field")
+			t.Fail()
+		}
+	})
+
+	t.Run("missing_file_path", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["missing_file_path"], &fileRule)
+		if err.Error() != "Missing 'path' field" {
+			t.Error(err)
+			t.Fail()
+		}
+	})
+
+	t.Run("missing_file_perm", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["missing_file_perm"], &fileRule)
+		if err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+	})
+
+	t.Run("invalid_perm", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["invalid_perm"], &fileRule)
+		if err == nil {
+			// TODO [prateeknischal]: Stronger validations on the file
+			// permissiosn
+			// t.Error("Accepted invalid permissions")
+			// t.Fail()
+		}
+	})
+
+	t.Run("invalid_ir", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["invalid_ir"], &fileRule)
+		if err == nil {
+			t.Error("Should have failed")
+			t.Fail()
+		}
+	})
+
+	t.Run("invalid_obj", func(t *testing.T) {
+		var fileRule libauditgo.FileAuditRule
+		err := UnmarshalAuditRule(fileAuditRules["invalid_obj"], &fileRule)
+		if err == nil {
+			t.Error("Should have failed for invalid object")
+			t.Fail()
+		}
+	})
+}
+
+func TestUnmarshalSyscallAuditRule(t *testing.T) {
+	t.Run("valid_rule", func(t *testing.T) {
+		var syscallRule libauditgo.SyscallAuditRule
+		if err := UnmarshalAuditRule(
+			syscallRules["valid_rule"], &syscallRule); err != nil {
+			t.Error(err)
+			t.Fail()
+		}
+
+		if syscallRule.Action != "always" ||
+			syscallRule.Syscalls[1] != "read" ||
+			syscallRule.Keys[0] != "useless_rule" ||
+			syscallRule.Filter != "exit" {
+			t.Error("Missing expected field")
+			t.Fail()
+		}
+	})
+
+	t.Run("missing_action", func(t *testing.T) {
+		var syscallRule libauditgo.SyscallAuditRule
+		err := UnmarshalAuditRule(syscallRules["missing_action"], &syscallRule)
+		if err.Error() != "Missing 'action' field" {
+			t.Error("Unexpected error message")
+			t.Fail()
+		}
+	})
+
+	t.Run("invalid_ir", func(t *testing.T) {
+		var syscallRule libauditgo.SyscallAuditRule
+		err := UnmarshalAuditRule(syscallRules["invalid_ir"], &syscallRule)
+		if err == nil {
+			t.Error("Should have failed")
+			t.Fail()
+		}
+	})
+
+	t.Run("invalid_obj", func(t *testing.T) {
+		var syscallRule libauditgo.SyscallAuditRule
+		err := UnmarshalAuditRule(syscallRules["invalid_obj"], &syscallRule)
+		if err == nil {
+			t.Error("Should have failed")
+			t.Fail()
+		}
+	})
+}

--- a/rule.go
+++ b/rule.go
@@ -395,7 +395,7 @@ func auditRuleFieldPairData(rule *auditRuleData, fpd *fieldPairData) error {
 		}
 	case AuditFileType:
 		if val, isString := fpd.fieldval.(string); isString {
-			if !(fpd.flags == int(AuditFilterExit) && fpd.flags == int(AuditFilterEntry)) {
+			if fpd.flags != int(AuditFilterExit) && fpd.flags != int(AuditFilterEntry) {
 				return fmt.Errorf("%v can only be used with exit and entry filter list", fpd.fieldname)
 			}
 			var fileval int
@@ -560,7 +560,6 @@ func (ard *auditRuleData) toAuditRule() (AuditRule, error) {
 		bufferOffset int
 	)
 	// parse syscall audit rule
-	var rule AuditRule
 	if !ard.isWatch() {
 		rule := &SyscallAuditRule{
 			Action: actionToName(ard.Action),
@@ -682,7 +681,6 @@ func (ard *auditRuleData) toAuditRule() (AuditRule, error) {
 		}
 		return rule, nil
 	}
-	return rule, nil
 }
 
 // printRule returns the string representation of a given kernel audit rule as


### PR DESCRIPTION
Add a public API to deserialize an IR representation from the config to
an AuditRule, File or Syscall type.

Add some basic tests for the Deserializer.

Fix some go vet warnings.